### PR TITLE
Update index.js for Gatsby video lesson #6...

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,8 @@
 import React from "react"
 import { Link } from 'gatsby'
 import Layout from "../components/Layout"
-import styles from '../styles/home.module.css'
+// import styles from '../styles/home.module.css'
+import * as styles from '../styles/home.module.css'
 
 export default function Home() {
   return (


### PR DESCRIPTION
In the new version of Gatsby (v3), CSS modules need to be imported like (as ES Modules) or you get an error. :) Love your teaching!